### PR TITLE
reuse core logic when opening a transition popup with segment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ env:
     - PIWIK_ROOT_DIR=$TRAVIS_BUILD_DIR/piwik
     # this variable controls the version of Piwik your tests will run against. increment it when
     # making your plugin compatible with the new version of Piwik.
-    - PIWIK_TEST_TARGET=2.15.1-b5
+    - PIWIK_TEST_TARGET=2.15.1-b6
     - secure: "Ev/dmJ2XI5VFFabMHlepjXKBVvFtSmge8H/nEjkwTgJXu5ZqZKeYcUjVDEC3G8+x5Jqpy0818JNjw1t4G/hK+8kTzB4Zw4PkEIo55xoAGkS8luN+5yT82SooyDjCqhiQ8vkJeD9NKsvWGAybeij1y16hmtdbgD8tBphPC8i6bcLGqkcgnVChF0MchE4weRDAxb49RejkteHOV6ig/6CR31SEYjjL6AqmFhS4aUE908HATYleNhCCDXLaWukO2sNmfTX8y5x5QB6INglUiSJjQcOvis83MWLDCpClNlchqDLU5jlO/2YDH4XnGVLBkl4mfX5vwVmQPr9OA3kaXzAQw3Vj3wymKj8lDxVPhMuld5OWLr/X9zZx0htocht6+6sQmuRjbL5e+GAw2loo4b5XXdpLe1+sEtoYgzc8U1NOA8k3zyikRPucINH/p431dcsncUCu9yjlyJClZxFt5tHgKdwj7gUCyuneSm0xGsBt/bZOKWbcoZvNISGtGeB1qPZFrDmj29INJo6Oecn1DtY2F7SMmy1ZOrUC5SLhrJIKageh30ek7/MJsgIOswg+MXdrvWJNWu53Am4rRHjKpxFjCvMlpNWTt4kg2F865moqswwTFIjTX9dy0ZvfhUx94gc2GDlroNjD76qLHD96BCqrevPmSCJv95O73WJUVNsnxhs="
   matrix:
     - TEST_SUITE=PluginTests MYSQL_ADAPTER=PDO_MYSQL TEST_AGAINST_PIWIK_BRANCH=$PIWIK_TEST_TARGET

--- a/javascripts/rowactions.js
+++ b/javascripts/rowactions.js
@@ -26,12 +26,7 @@ $(function () {
                 var segment = prev.attr('data-segment-filter');
                 if (segment) {
                     label = unescape(label);
-                    if (this.transitions === null) {
-                        this.transitions = new Piwik_Transitions('url', label, this, segment);
-                    } else {
-                        this.transitions.reset('url', label, segment);
-                    }
-                    this.transitions.showPopover();
+                    DataTable_RowActions_Transitions.launchForUrl(label, segment);
                 }
             }
         }

--- a/plugin.json
+++ b/plugin.json
@@ -10,7 +10,7 @@
     "license": "GPL v3+",
     "homepage": "http:\/\/piwik.org",
     "require": {
-        "piwik": ">=2.15.1-b5"
+        "piwik": ">=2.15.1-b6"
     },
     "authors": [
         {


### PR DESCRIPTION
refs piwik/piwik#9301 

Needs to be merged once piwik/piwik#9301 is merged and a new beta was released. Before that we need to require the new beta version in `plugin.json` and `.travis.yml`