### PR TITLE
Do not use table alias, this way we reuse existing joins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@
 
 language: php
 
+group: legacy
+
 php:
   - 5.6
   - 5.3.3
@@ -29,7 +31,7 @@ env:
     - PIWIK_ROOT_DIR=$TRAVIS_BUILD_DIR/piwik
     # this variable controls the version of Piwik your tests will run against. increment it when
     # making your plugin compatible with the new version of Piwik.
-    - PIWIK_TEST_TARGET=2.15.1-b6
+    - PIWIK_TEST_TARGET=2.15.1-b8
     - secure: "Ev/dmJ2XI5VFFabMHlepjXKBVvFtSmge8H/nEjkwTgJXu5ZqZKeYcUjVDEC3G8+x5Jqpy0818JNjw1t4G/hK+8kTzB4Zw4PkEIo55xoAGkS8luN+5yT82SooyDjCqhiQ8vkJeD9NKsvWGAybeij1y16hmtdbgD8tBphPC8i6bcLGqkcgnVChF0MchE4weRDAxb49RejkteHOV6ig/6CR31SEYjjL6AqmFhS4aUE908HATYleNhCCDXLaWukO2sNmfTX8y5x5QB6INglUiSJjQcOvis83MWLDCpClNlchqDLU5jlO/2YDH4XnGVLBkl4mfX5vwVmQPr9OA3kaXzAQw3Vj3wymKj8lDxVPhMuld5OWLr/X9zZx0htocht6+6sQmuRjbL5e+GAw2loo4b5XXdpLe1+sEtoYgzc8U1NOA8k3zyikRPucINH/p431dcsncUCu9yjlyJClZxFt5tHgKdwj7gUCyuneSm0xGsBt/bZOKWbcoZvNISGtGeB1qPZFrDmj29INJo6Oecn1DtY2F7SMmy1ZOrUC5SLhrJIKageh30ek7/MJsgIOswg+MXdrvWJNWu53Am4rRHjKpxFjCvMlpNWTt4kg2F865moqswwTFIjTX9dy0ZvfhUx94gc2GDlroNjD76qLHD96BCqrevPmSCJv95O73WJUVNsnxhs="
   matrix:
     - TEST_SUITE=PluginTests MYSQL_ADAPTER=PDO_MYSQL TEST_AGAINST_PIWIK_BRANCH=$PIWIK_TEST_TARGET
@@ -69,7 +71,7 @@ install:
   - '[ -d ./tests/travis/.git ] || sh -c "rm -rf ./tests/travis && git clone https://github.com/piwik/travis-scripts.git ./tests/travis"'
   - cd ./tests/travis ; git checkout master ; cd ../..
 
-  - export GENERATE_TRAVIS_YML_COMMAND="php ./tests/travis/generator/main.php generate:travis-yml --plugin=\"CustomDimensions\" --force-ui-tests --verbose"
+  - export GENERATE_TRAVIS_YML_COMMAND="php ./tests/travis/generator/main.php generate:travis-yml --plugin=\"CustomDimensions\" --verbose"
   - '[[ "$TRAVIS_JOB_NUMBER" != *.1 || "$TRAVIS_PULL_REQUEST" != "false" ]] || ./tests/travis/autoupdate_travis_yml.sh'
 
   - ./tests/travis/checkout_test_against_branch.sh

--- a/Archiver.php
+++ b/Archiver.php
@@ -160,10 +160,10 @@ class Archiver extends \Piwik\Plugin\Archiver
         $dataArray->setActionMetricsIds($metricIds);
 
         $select = "log_link_visit_action.$valueField,
-                  actionAlias.name as url,
+                  log_action.name as url,
                   sum(log_link_visit_action.time_spent) as `" . Metrics::INDEX_PAGE_SUM_TIME_SPENT . "`,
-                  sum(case visitAlias.visit_total_actions when 1 then 1 when 0 then 1 else 0 end) as `" . Metrics::INDEX_BOUNCE_COUNT . "`,
-                  sum(IF(visitAlias.last_idlink_va = log_link_visit_action.idlink_va, 1, 0)) as `" . Metrics::INDEX_PAGE_EXIT_NB_VISITS . "`";
+                  sum(case log_visit.visit_total_actions when 1 then 1 when 0 then 1 else 0 end) as `" . Metrics::INDEX_BOUNCE_COUNT . "`,
+                  sum(IF(log_visit.last_idlink_va = log_link_visit_action.idlink_va, 1, 0)) as `" . Metrics::INDEX_PAGE_EXIT_NB_VISITS . "`";
 
         $select = $this->addMetricsToSelect($select, $metricsConfig);
 
@@ -171,13 +171,11 @@ class Archiver extends \Piwik\Plugin\Archiver
             "log_link_visit_action",
             array(
                 "table"  => "log_visit",
-                "tableAlias"  => "visitAlias",
-                "joinOn" => "visitAlias.idvisit = log_link_visit_action.idvisit"
+                "joinOn" => "log_visit.idvisit = log_link_visit_action.idvisit"
             ),
             array(
                 "table"  => "log_action",
-                "tableAlias"  => "actionAlias",
-                "joinOn" => "log_link_visit_action.idaction_url = actionAlias.idaction"
+                "joinOn" => "log_link_visit_action.idaction_url = log_action.idaction"
             )
         );
 

--- a/plugin.json
+++ b/plugin.json
@@ -10,7 +10,7 @@
     "license": "GPL v3+",
     "homepage": "http:\/\/piwik.org",
     "require": {
-        "piwik": ">=2.15.1-b6"
+        "piwik": ">=2.15.1-b8"
     },
     "authors": [
         {


### PR DESCRIPTION
We can only merge this one after PR https://github.com/piwik/piwik/pull/9314 was merged and after a new beta was released.  Then we need to require the new Piwik beta version in plugin.json and .travis.yml and see if it still works before merging this PR. 

Not using an alias will make the query/archiving faster as we can reuse existing joins used by core this way