### PR TITLE
Fix auto suggest for action dimensions > 1

### DIFF
--- a/Dao/AutoSuggest.php
+++ b/Dao/AutoSuggest.php
@@ -32,7 +32,7 @@ class AutoSuggest
         $table = Common::prefixTable('log_link_visit_action');
         $query = "SELECT $name, count($name) as countName FROM $table
                   WHERE idsite = ? and server_time > $startDate and $name is not null
-                  GROUP by custom_dimension_1
+                  GROUP by $name
                   ORDER BY countName DESC LIMIT $maxValuesToReturn";
         $rows = Db::get()->fetchAll($query, array($idSite));
 

--- a/tests/System/AutoSuggestTest.php
+++ b/tests/System/AutoSuggestTest.php
@@ -89,7 +89,7 @@ class AutoSuggestTest extends SystemTestCase
     {
         $autoSuggest = new AutoSuggest();
         $values = $autoSuggest->getMostUsedActionDimensionValues(array('index' => 3), $idSite = 1, $limit = 10);
-        $this->assertEquals(array('343', 'value5', 'en_US'), $values);
+        $this->assertEquals(array('en_US', 'value5', '343', 'value5 5'), $values);
     }
 
     public static function getOutputPrefix()


### PR DESCRIPTION
The SQL-Query for auto suggest values for action dimensions had a fixed `GROUP BY custom_dimension_1`. This caused action dimensions != 1 to have incorrect auto suggest values.