### PR TITLE
Add secondary AutoSuggest order column

### DIFF
--- a/Dao/AutoSuggest.php
+++ b/Dao/AutoSuggest.php
@@ -33,7 +33,7 @@ class AutoSuggest
         $query = "SELECT $name, count($name) as countName FROM $table
                   WHERE idsite = ? and server_time > $startDate and $name is not null
                   GROUP by $name
-                  ORDER BY countName DESC LIMIT $maxValuesToReturn";
+                  ORDER BY countName DESC, $name ASC LIMIT $maxValuesToReturn";
         $rows = Db::get()->fetchAll($query, array($idSite));
 
         $values = array();

--- a/tests/System/AutoSuggestTest.php
+++ b/tests/System/AutoSuggestTest.php
@@ -68,14 +68,14 @@ class AutoSuggestTest extends SystemTestCase
     {
         $autoSuggest = new AutoSuggest();
         $values = $autoSuggest->getMostUsedActionDimensionValues(array('index' => 1), $idSite = 1, $limit = 60);
-        $this->assertEquals(array('en', 'value3', 'value5 3', ''), $values);
+        $this->assertEquals(array('en', '', 'value3', 'value5 3'), $values);
     }
 
     public function test_getMostUsedActionDimensionValues_shouldApplyLimit()
     {
         $autoSuggest = new AutoSuggest();
         $values = $autoSuggest->getMostUsedActionDimensionValues(array('index' => 1), $idSite = 1, $limit = 2);
-        $this->assertEquals(array('en', 'value3'), $values);
+        $this->assertEquals(array('en', ''), $values);
     }
 
     public function test_getMostUsedActionDimensionValues_shouldApplyIdSite()
@@ -89,7 +89,7 @@ class AutoSuggestTest extends SystemTestCase
     {
         $autoSuggest = new AutoSuggest();
         $values = $autoSuggest->getMostUsedActionDimensionValues(array('index' => 3), $idSite = 1, $limit = 10);
-        $this->assertEquals(array('en_US', 'value5', '343', 'value5 5'), $values);
+        $this->assertEquals(array('en_US', '343', 'value5', 'value5 5'), $values);
     }
 
     public static function getOutputPrefix()

--- a/tests/System/expected/test__actionScope__API.getSuggestedValuesForSegment.xml
+++ b/tests/System/expected/test__actionScope__API.getSuggestedValuesForSegment.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>
 	<row>en</row>
+	<row/>
 	<row>value3</row>
 	<row>value5 3</row>
-	<row/>
 </result>


### PR DESCRIPTION
Orders results of AutoSuggest by secondary column (`$name`) in order to receive deterministic results.

[refs #71]