### PR TITLE
Clear cache when configuring new dimension

### DIFF
--- a/API.php
+++ b/API.php
@@ -13,6 +13,7 @@ use Piwik\DataTable\Row;
 
 use Piwik\Archive;
 use Piwik\DataTable;
+use Piwik\Filesystem;
 use Piwik\Metrics;
 use Piwik\Piwik;
 use Piwik\Plugins\CustomDimensions\Dao\Configuration;
@@ -120,6 +121,7 @@ class API extends \Piwik\Plugin\API
 
         Cache::deleteCacheWebsiteAttributes($idSite);
         Cache::clearCacheGeneral();
+        Filesystem::deleteAllCacheOnUpdate();
 
         return $idDimension;
     }


### PR DESCRIPTION
to prevent: Action 'getCustomDimension' not found in the module 'CustomDimensions'

refs DEV-1870
![image](https://user-images.githubusercontent.com/273120/73614775-02286900-4667-11ea-84c4-a989a97228d8.png)
